### PR TITLE
Remove Clutter dependency

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -16,7 +16,6 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import Clutter from 'gi://Clutter';
 import * as History from 'resource:///org/gnome/shell/misc/history.js';
 import {Extension, InjectionManager} from 'resource:///org/gnome/shell/extensions/extension.js';
 
@@ -87,7 +86,7 @@ export default class HistoryManagerPrefixSearchExtension extends Extension {
                     return true;
                 }
 
-                return Clutter.EVENT_PROPAGATE;
+                return false;
                 /* eslint-enable no-invalid-this */
             };
         });

--- a/prefs.js
+++ b/prefs.js
@@ -1,7 +1,7 @@
 /* exported init, buildPrefsWidget */
 
 import Adw from 'gi://Adw';
-import Clutter from 'gi://Clutter';
+import Gdk from 'gi://Gdk?version=4.0';
 import Gtk from 'gi://Gtk';
 
 import {ExtensionPreferences, gettext as _} from 'resource:///org/gnome/Shell/Extensions/js/extensions/prefs.js';
@@ -23,17 +23,17 @@ export default class HistoryManagerPrefixSearchExtensionPreferences extends Exte
         const controlKeysComboRow = new Adw.ComboRow({
             title: _('Control keys'),
             model: controlKeysOptions,
-            selected: settings.get_int('key-previous') === Clutter.KEY_Page_Up ? 0 : 1,
+            selected: settings.get_int('key-previous') === Gdk.KEY_Page_Up ? 0 : 1,
         });
         controlKeysComboRow.connect(
             'notify::selected',
             comboRow => {
                 if (comboRow.selected === 0) {
-                    settings.set_int('key-previous', Clutter.KEY_Page_Up);
-                    settings.set_int('key-next', Clutter.KEY_Page_Down);
+                    settings.set_int('key-previous', Gdk.KEY_Page_Up);
+                    settings.set_int('key-next', Gdk.KEY_Page_Down);
                 } else {
-                    settings.set_int('key-previous', Clutter.KEY_Up);
-                    settings.set_int('key-next', Clutter.KEY_Down);
+                    settings.set_int('key-previous', Gdk.KEY_Up);
+                    settings.set_int('key-next', Gdk.KEY_Down);
                 }
             }
         );


### PR DESCRIPTION
## Summary

Remove the unnecessary `Clutter` dependency from the extension.

## Motivation

On recent Fedora GNOME installations, the `Clutter-1.0` GI typelib is not always installed by default. This causes the preferences dialog to fail with:

```
Typelib file for namespace 'Clutter' (any version) not found
```

The extension used Clutter only for:

* Key symbol constants (`Clutter.KEY_*`)
* `Clutter.EVENT_PROPAGATE`

Since neither requires Clutter specifically, the dependency can be removed.

## Changes

### prefs.js

* Replace `Clutter.KEY_*` with `Gdk.KEY_*`
* Import Gdk explicitly via:

```js
import Gdk from 'gi://Gdk?version=4.0';
```
* Remove the Clutter import

`Gdk.KEY_*` keyvals are identical to the corresponding Clutter keyvals.

### extension.js

* Remove `import Clutter`
* Replace:

```js
return Clutter.EVENT_PROPAGATE;
```

with:

```js
return false;
```

In GNOME Shell key handlers:

* `true` = event handled
* `false` = propagate

This preserves existing behavior.

## Result

* Preferences window works on minimal Fedora GNOME installs
* No runtime dependency on the Clutter GI typelib
* No change in functionality

Tested on GNOME Shell 49 (Fedora Workstation 43).

Closes sustmi/gnome-shell-extension-historymanager-prefix-search#7
